### PR TITLE
Hold piece scaling + adjustments

### DIFF
--- a/code.js
+++ b/code.js
@@ -71,7 +71,7 @@ this.addEventListener('keydown', event => {
     if (firstMove && event.key != 'Escape') firstMovement();
     if (event.key == controlSettings.resetKey) { playSound('retry'); startGame(); }
     if (gameEnd) return;
-    if (event.key.toLowerCase() == controlSettings.cwKey) rotate("CW");
+    if (event.key.toLowerCase() == controlSettings.cwKey || event.key.toLowerCase() == 'x') rotate("CW");
     if (event.key.toLowerCase() == controlSettings.ccwKey) rotate("CCW");
     if (event.key.toLowerCase() == controlSettings.rotate180Key) rotate("180");
     if (event.key.toLowerCase() == controlSettings.hdKey) harddrop();

--- a/code.js
+++ b/code.js
@@ -70,7 +70,7 @@ this.addEventListener('keydown', event => {
     if (firstMove && event.key != 'Escape') firstMovement();
     if (event.key == controlSettings.resetKey) { playSound('retry'); startGame(); }
     if (gameEnd) return;
-    if (event.key.toLowerCase() == controlSettings.cwKey || event.key.toLowerCase() == 'x') rotate("CW");
+    if (event.key.toLowerCase() == controlSettings.cwKey) rotate("CW");
     if (event.key.toLowerCase() == controlSettings.ccwKey) rotate("CCW");
     if (event.key.toLowerCase() == controlSettings.rotate180Key) rotate("180");
     if (event.key.toLowerCase() == controlSettings.hdKey) harddrop();

--- a/code.js
+++ b/code.js
@@ -42,13 +42,12 @@ function init() {
 
 function sizeCanvas() {
     divBoard.setAttribute('style', ''); renderStyles();
-    canvasField.offsetWidth = divBoard.width;
     [canvasField, canvasNext, canvasHold].forEach(c => {
-        c.width = Math.round(c.offsetWidth / 10) * 10;
-        c.height = Math.round(c.offsetHeight / 40) * 40;
+        c.width = c.offsetWidth;
+        c.height = c.offsetHeight;
     });
-    divBoard.style.width = `${canvasField.width}px`
-    divBoard.style.height = `${canvasField.height / 2}px`
+    divBoard.style.width = `${canvasField.width}px`;
+    divBoard.style.height = `${canvasField.height / 2}px`;
     minoSize = canvasField.width / 10;
     boardWidth = canvasField.offsetWidth, boardHeight = canvasField.offsetHeight;
     nextWidth = canvasNext.offsetWidth, nextHeight = canvasNext.offsetHeight;
@@ -495,7 +494,7 @@ function updateHold() {
     coords.forEach(([x, y]) => holdQueueGrid[y + dy][x + dx] = 'A ' + name)
     const len = Math.round(minoSize / 2);
     const [shiftX, shiftY] = [isO || isI ? 0 : len, isI ? 0 : len];
-    renderToCanvas(ctxH, holdQueueGrid, 2, [shiftX, shiftY], holdWidth, holdHeight)
+    renderToCanvas(ctxH, holdQueueGrid, 2, [shiftX, shiftY], holdWidth, holdHeight-50)
     if (gameSettings.gamemode == 8 || !displaySettings.colouredQueues) return;
     canvasHold.style.outline = `0.2vh solid ${holdPiece.piece.colour}`
 }
@@ -988,6 +987,7 @@ const attackValues = {
     'TSPIN MINI DOUBLE': [1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 6],
     'ALL CLEAR': 10,
 };
+
 const cleartypes = { '0': '', '1': 'Single', '2': 'Double', '3': 'Triple', '4': 'Quad' };
 const scoringTable = { '': 0, 'TSPIN': 400, 'TSPIN MINI': 100, 'SINGLE': 100, 'DOUBLE': 300, 'TRIPLE': 500, 'QUAD': 800, 'TSPIN SINGLE': 800, 'TSPIN DOUBLE': 1200, 'TSPIN TRIPLE': 1600, 'TSPIN MINI SINGLE': 200, 'TSPIN MINI DOUBLE': 400, 'ALL CLEAR': 3500 }
 const modesText = { 0: 'Zen', 1: 'Lines', 2: 'Score', 3: 'Damage', 4: 'Remaining', 5: 'Lines Survived', 6: 'Sent', 7: 'Combo', 8: 'Lines' }

--- a/code.js
+++ b/code.js
@@ -494,7 +494,7 @@ function updateHold() {
     coords.forEach(([x, y]) => holdQueueGrid[y + dy][x + dx] = 'A ' + name)
     const len = Math.round(minoSize / 2);
     const [shiftX, shiftY] = [isO || isI ? 0 : len, isI ? 0 : len];
-    renderToCanvas(ctxH, holdQueueGrid, 2, [shiftX, shiftY], holdWidth, holdHeight-50)
+    renderToCanvas(ctxH, holdQueueGrid, 2, [shiftX, shiftY], holdWidth, holdHeight)
     if (gameSettings.gamemode == 8 || !displaySettings.colouredQueues) return;
     canvasHold.style.outline = `0.2vh solid ${holdPiece.piece.colour}`
 }

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
         </button>
         <div class="settingLayout"><label>BG hex</label> <input class="option textInput" type="text" id="background" /></div>
         <div class="settingLayout"><label>Board Opacity</label> <input class="option range" type="range" id="boardOpacity" oninput="sliderChange(this)" min="0" max="100" step="1"/></div>
-        <div class="settingLayout"><label>Board Size</label> <input class="option range" oninput="sliderChange(this)" type="range" id="boardHeight" min="0" max="100" step="1" /></div>
+        <div class="settingLayout"><label>Board Size</label> <input class="option range" oninput="sliderChange(this)" type="range" id="boardHeight" min="0" max="130" step="1" /></div>
         <div class="settingLayout"><label>Enable Grid</label> <input class="option check" type="checkbox" id="showGrid" /></div>
         <div class="settingLayout"><label>Grid opacity</label> <input class="option range" oninput="sliderChange(this)" type="range" id="gridopacity" min="0" max="100" step="2" /></div>
         <div class="settingLayout"><label>Shadow opacity</label> <input class="option range" oninput="sliderChange(this)" type="range" id="shadowOpacity" min="0" max="100" step="5" /></div>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cb731e4c-0b8d-4a20-b655-603fe069b374)
![image](https://github.com/user-attachments/assets/360d5467-cae3-4d48-b67e-ae1be473b3b3)

I've changed the `sizeCanvas()` function to make the hold piece appear with the correct scaling, and allowed a large maximum board size in the html slider. However, the grid lines seem to appear on the pieces at a browser scaling of something other than 100% (which is not an issue in the original). 
![image](https://github.com/user-attachments/assets/08168893-edd8-4d65-935f-b5fccb92caae)

Could you please review the code and edit as necessary to hopefully fix the hold piece scaling? I wasn't sure whether to open an issue or a PR for this, but I hope this is okay.