### PR TITLE
Load a custom map from the URL if provided

### DIFF
--- a/src/features/editboard.js
+++ b/src/features/editboard.js
@@ -76,6 +76,9 @@ export class BoardEditor {
                 return col
             });
         })
+        while (board.length < 40) {
+            board.push(["", "", "", "", "", "", "", "", "", ""]);
+        }
         return { board, next, hold }
     }
 }

--- a/src/game.js
+++ b/src/game.js
@@ -143,6 +143,7 @@ export class GameClass {
             this.bag.setQueue(next.split(","));
             this.hold.piece = getPiece(hold);
             this.mechanics.spawnPiece(this.bag.cycleNext());
+            this.history.save();
         }
     }
 

--- a/src/game.js
+++ b/src/game.js
@@ -1,4 +1,4 @@
-import { Bag } from "./mechanics/randomisers.js";
+import { Bag, getPiece } from "./mechanics/randomisers.js";
 import { Board } from "./mechanics/board.js";
 import { Controls } from "./movement/controls.js";
 import { Hold } from "./mechanics/hold.js";
@@ -72,6 +72,7 @@ export class GameClass {
         this.renderer.setEditPieceColours();
         this.sounds.initSounds();
         this.startGame();
+        this.loadStateFromString(new URLSearchParams(window.location.search).get("map"));
         this.menuactions.addRangeListener();
         this.modals.generate.addMenuListeners();
         this.modals.generate.generateGamemodeMenu();
@@ -133,6 +134,16 @@ export class GameClass {
         this.elementReason.textContent = top;
         this.elementResult.textContent = bottom;
         this.profilestats.saveSession();
+    }
+
+    loadStateFromString(input) {
+        if (input) {
+            const { board, next, hold } = this.boardeditor.convertFromMap(input);
+            this.board.boardState = board;
+            this.bag.setQueue(next.split(","));
+            this.hold.piece = getPiece(hold);
+            this.mechanics.spawnPiece(this.bag.cycleNext());
+        }
     }
 
     resetState(seed = undefined) {

--- a/src/menus/menuactions.js
+++ b/src/menus/menuactions.js
@@ -1,5 +1,4 @@
 import { Game } from "../main.js";
-import { getPiece } from "../mechanics/randomisers.js";
 import { toExpValue } from "./modals.js";
 
 export class MenuActions {
@@ -179,11 +178,7 @@ export class MenuActions {
 
     setBoard() {
         const input = prompt("Enter Map String Here:")
-        const { board, next, hold } = Game.boardeditor.convertFromMap(input);
-        Game.board.boardState = board;
-        Game.bag.setQueue(next.split(","));
-        Game.hold.piece = getPiece(hold);
-        Game.mechanics.spawnPiece(Game.bag.cycleNext());
+        Game.loadStateFromString(input);
         Game.modals.generate.notif("Map Loaded", "Custom map has successfully loaded", "message");
     }
 


### PR DESCRIPTION
This PR allows to load maps using a URL param, in addition to the menu option.

Try for example: http://localhost:8000/?map=GGG_____GGGGG____GGGGGG___GGGGGGG____GGG?i,l,i,o

Goes well with a map editor [like this one](https://you.have.fail/tetrio/mapeditor/).

Additionally:

- Save states with fewer rows than 40 will be loaded correctly (padded to 40 rows)
- Loading a save state via the menu is now an undoable action