### PR TITLE
Block skins can be uploaded as a png file + rendering-related bug fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,6 +138,12 @@
         <div class="settingsBox">
             <div class="settingRow"><p>Background URL/Hex</p> <input class="option textInput" type="text" id="background" /></div>
             <div class="settingRow"><p>Block Skin URL/Name</p> <input class="option textInput" type="text" id="skin" list="options"/></div>
+            <div class="settingRow"><p>Upload Block Skin (.png)</p> 
+                <div id="uploadSettings" class="settingPanelButton smallerPanelButton fileInputContainer" style="box-sizing: border-box;" onclick="document.getElementById('uploadSkin').click()">
+                    <input type="file" id="uploadSkin" onchange="menu.uploadSkin(this)" hidden accept=".png">
+                    <div class="img"></div>
+                </div>
+            </div>
             <div class="settingRow"><p>High Resolution<br>(reload after)</p> <input class="option check" type="checkbox" id="highRes" /></div>
             <div class="settingRow"><p>Board Opacity</p> <input class="option range" type="range" id="boardOpacity" min="0" max="100" step="1"/></div>
             <div class="settingRow"><p>Board Size</p> <input class="option range" type="range" id="boardHeight" min="0" max="130" step="1" /></div>

--- a/src/display/pixirender.js
+++ b/src/display/pixirender.js
@@ -165,7 +165,11 @@ export class PixiRender {
 
     async generateTextures() {
         let url = Game.settings.display.skin;
-        if (defaultSkins.includes(url)) url = `./assets/skins/${url}.png`;
+        if (!/^https?:\/\//.test(url) && /\.[a-zA-Z0-9]+$/.test(url)){
+            url = localStorage.getItem("customSkin");
+        }else if (defaultSkins.includes(url)){
+            url = `./assets/skins/${url}.png`;
+        }
         let texture;
         try {
             texture = await PIXI.Assets.load(url);

--- a/src/menus/menuactions.js
+++ b/src/menus/menuactions.js
@@ -250,4 +250,18 @@ export class MenuActions {
         };
     }
 
+    uploadSkin(el) {
+        const reader = new FileReader();
+        //read skin as base64 and save it in localStorage
+        const file = el.files[0]
+        reader.readAsDataURL(file);
+        reader.onload = () => {
+            const base64 = reader.result;
+            localStorage.setItem("customSkin", base64);
+            Game.modals.generate.notif("Skin Uploaded", "Skin successfully uploaded", "message");
+            el.value = "";
+            document.getElementById("skin").value = `${file.name}`;
+        };
+    }
+
 }

--- a/src/menus/modals.js
+++ b/src/menus/modals.js
@@ -115,11 +115,18 @@ export class ModalActions {
         this.closeDialog(document.getElementById(id));
         if (id != 'changeRangeValue' && id != "frontdrop" && Game.started && !Game.ended) Game.movement.startTimers();
         Game.menuactions.saveSettings();
-        if (id == "displayDialog") Game.renderer.renderStyles(true);
+        if (id == "displayDialog"){
+            Game.renderer.renderStyles(true);
+            setTimeout(() => {
+                Game.renderer.updateNext();
+                Game.renderer.updateHold();
+            }, 1);
+        }
 
         const restartMenus = ["gameDialog", "gamemodeDialog", "gameEnd", "goalsDialog", "competitiveDialog"];
         if (restartMenus.includes(id)) Game.controls.retry(false);
         if (id == "changeRangeValue") this.open = true;
+
     }
 
     closeDialog(element) {

--- a/styles/menus.css
+++ b/styles/menus.css
@@ -228,6 +228,31 @@ button>img {
     border-color: var(--p-green);
 }
 
+.fileInputContainer{
+    border: 0.1vmin solid white;
+}
+
+.fileInputContainer:hover{
+    border-color: var(--p-green);
+}
+
+.fileInputContainer .img{
+    -webkit-mask-image: url('../assets/icons/upload.svg');
+    -webkit-mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-image: url('../assets/icons/upload.svg');
+    mask-repeat: no-repeat;
+    mask-size: contain;
+    background: white;
+    height: 90%;
+    width: 75%;
+    transform: translateY(10%);
+}
+
+.fileInputContainer:hover .img{
+    background: var(--p-green);
+}
+
 .keybind {
     padding: 0.5vh;
     background-color: var(--invis);


### PR DESCRIPTION
Block skins can now be uploaded as a .png file
<img width="551" height="772" alt="image" src="https://github.com/user-attachments/assets/9759beb0-5ef3-4a5a-a71e-c36d29ed3fb9" />

The code converts the uploaded png into base64 string and saves it in local storage. It will also set the value of the block skin textbox to the file name. During rendering, it will check if the block skin setting follows a file name format, and if so it will load the skin stored in the local storage's

Also fixed a bug where the queue and hold pieces disappear after the display modal is closed. The fix isnt ideal since it uses setTimeout, so a more optimal solution is welcome